### PR TITLE
Update README with new view admins link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please don't post shallow dismissals, especially of other people's work, thought
 
 ## Code of Conduct
 
-“ZA Tech” in this document refers to the ZA Tech Slack organization at [https://zatech.slack.com/](https://zatech.slack.com/). “The administrators” refers to the administrators on this organization, which can be accessed [here](https://zatech.slack.com/team), or by accessing "Workspace Directory" in the top-right drop-down menu on the web. (You must be a member of the organization to view.)
+“ZA Tech” in this document refers to the ZA Tech Slack organization at [https://zatech.slack.com/](https://zatech.slack.com/). “The administrators” refers to the administrators on this organization, which can be accessed [here](https://zatech.slack.com/account/workspace-settings#admins), or by accessing "Workspace Directory" in the top-right drop-down menu on the web, and from the settings button next to name and title select `Admins`. (You must be a member of the organization to view.)
 
 ZA Tech is dedicated to providing a harassment-free experience for everyone. We do not tolerate harassment of participants in any form.
 


### PR DESCRIPTION
The web URI has changed locations for the quick-jump to view admins,
and it will no longer jump to open the Slack client to show you the admins.
So best to use the web link and expand direction on how to view admins
from inside the Slack client(s).