### PR TITLE
Remove mention of #codeofconduct channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ While the community aims to be a place for members of the community to meet and 
 
 If you are being harassed by a member of ZA Tech, notice that someone else is being harassed, or have any other concerns there are a few methods for reporting. Administrators will respond as soon as they are able. If the person who is harassing you is on the admin team, they will recuse themselves from handling your incident. Listed from most public to most anonymous:
 
-* Post a message in the [#codeofconduct channel](https://zatech.slack.com/messages/codeofconduct/)
+* Create a private channel with the admins
+  * Create a private channel called `admins-$YOUR_USERNAME`, e.g. `admins-cdanvers`
+  * Invite the admin team to your new private channel using `/invite @adminteam`
 * DM an [administrator](https://zatech.slack.com/account/workspace-settings#admins)
 * Submit an [anonymous report](https://zatech.co.za/report)
 


### PR DESCRIPTION
We should
- remove/archive the #codeofconduct channel.
- remove it from the default channels
- document how to create an 🔒admins- channel

Discussions around the Code of Conduct can be done in 🔒admins- channels.

#codeofconduct being a default channel has a few downsides. It has been used in bad faith by people to dogpile other users or threads, derailing any productive or valuable discussion.

It's also been abused by people trying to broadcast messages to a lot of people even when asked to no longer comment on incidents or threads, which then wastes more time of the admins and moderators, when they're already trying to prioritise the right issues and reduce harm.

It's also been used by mistake by people which then spams 8000 users.